### PR TITLE
fix: update budget limits handling and improve month bounds parsing

### DIFF
--- a/backend/src/services/budget_service.py
+++ b/backend/src/services/budget_service.py
@@ -10,7 +10,10 @@ def _to_out(doc) -> BudgetOut:
 
 
 async def upsert_budget(user: User, data: BudgetUpsert) -> BudgetOut:
-    limits = {str(k): float(v) for k, v in data.limits.items() if v >= 0}
+    # `data.limits` keys are Category enum members (Pydantic coerces from str).
+    # `str(Category.FOOD)` returns "Category.FOOD", not "food" — must use `.value`
+    # so stored keys match what the frontend sends back when querying stats.
+    limits = {k.value: float(v) for k, v in data.limits.items() if v >= 0}
     doc = await budget_repository.upsert(user.id, data.month, limits)
     return _to_out(doc)
 

--- a/backend/src/services/transaction_service.py
+++ b/backend/src/services/transaction_service.py
@@ -1,5 +1,4 @@
-from calendar import monthrange
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from beanie import PydanticObjectId
@@ -19,13 +18,19 @@ from src.schemas.transaction_schemas import (
 
 
 def _month_bounds(month: str) -> tuple[datetime, datetime]:
-    """Parse 'YYYY-MM' into [start, end) datetime range. Raises 400 on bad input."""
+    """Parse 'YYYY-MM' into a half-open [start, end) datetime range.
+
+    `end` is the first instant of the *next* month so the repo query can use
+    `$lt: end` without missing transactions that land in the last microsecond
+    of the month.
+    """
     try:
         year, mo = month.split("-")
         y, m = int(year), int(mo)
-        last = monthrange(y, m)[1]
+        if not (1 <= m <= 12):
+            raise ValueError("month out of range")
         start = datetime(y, m, 1)
-        end = datetime(y, m, last, 23, 59, 59, 999000)
+        end = datetime(y + 1, 1, 1) if m == 12 else datetime(y, m + 1, 1)
         return start, end
     except (ValueError, AttributeError):
         raise HTTPException(status_code=400, detail="Invalid month format (expected YYYY-MM)")
@@ -148,8 +153,6 @@ async def get_month_stats(user: User, month: str) -> StatsResponse:
 
 async def recent_spend_summary(user_id: PydanticObjectId, days: int = 30) -> dict:
     """Compact summary used by ai_utils to inject user spending into prompts."""
-    from datetime import timedelta
-
     end = datetime.utcnow()
     start = end - timedelta(days=days)
     agg = await transaction_repository.aggregate_month(user_id, start, end)

--- a/frontend/src/components/pages/money/BudgetPage.tsx
+++ b/frontend/src/components/pages/money/BudgetPage.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Loader2 } from "lucide-react"
-import { api, EXPENSE_CATEGORIES, type Category } from "@/lib/api"
+import { api, ApiError, EXPENSE_CATEGORIES, type Category } from "@/lib/api"
 import { currentMonthString, fmtINR } from "@/lib/utils"
 import { toast, toastError } from "@/lib/toast"
-import { ApiError } from "@/lib/api"
 
 export default function BudgetPage() {
   const qc = useQueryClient()


### PR DESCRIPTION
- Adjusted budget limits processing in `upsert_budget` to ensure keys match frontend expectations by using `.value` of Category enums.
- Enhanced `_month_bounds` function to clarify the datetime range parsing and ensure correct handling of month boundaries.
- Removed redundant import in `recent_spend_summary` for cleaner code.